### PR TITLE
bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/changes made
+++ b/changes made
@@ -1,0 +1,10 @@
+1. stored the player's score in session storage which serves as a backup, as currrently the player score gets deleted if player refreshes on getting to the end quiz section, so this allows the score to persist even after reload for a given period of time
+
+2. noticed during game play, that immediately after completing a quiz session, and the user is directed to the end quiz section if the user cancels the end quiz transaction, the users then gets access to the quiz session again, meaning they can retake the quiz as many times just by canceling the end quiz transaction after they just completed that quiz.
+Fixed this issue by setting the quizStarted value to false when the quiz ended transaction fails.
+
+3. noticed that the player history was not showing only the quizzes that the player had partaken in but it was showing all quizzes that were available,, fixed this issue, by attaching a note to the start quiz transaction, the note would be added only to quizzes the player had not taken before, so we can then use that note to get quizzes that the player had partaken in.
+
+4. updated the notifications of the code base
+
+5. fixed useEffect warning that popped up whenever the pages gets redirected to the results page.

--- a/src/components/Notifications.jsx
+++ b/src/components/Notifications.jsx
@@ -1,47 +1,18 @@
 import React from "react";
-import {ToastContainer} from "react-toastify";
-import PropTypes from "prop-types";
+import { ToastContainer } from "react-toastify";
 
 const Notification = () => (
-    <ToastContainer
-        position="bottom-center"
-        autoClose={5000}
-        hideProgressBar
-        newestOnTop
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable={false}
-        pauseOnHover
-    />
+  <ToastContainer
+    position="bottom-center"
+    autoClose={10000}
+    hideProgressBar
+    newestOnTop
+    closeOnClick
+    rtl={false}
+    pauseOnFocusLoss
+    draggable={false}
+    pauseOnHover
+  />
 );
 
-const NotificationSuccess = ({text}) => (
-    <div>
-        <i className="bi bi-check-circle-fill text-success mx-2"/>
-        <span className="text-secondary mx-1">{text}</span>
-    </div>
-);
-
-const NotificationError = ({text}) => (
-    <div>
-        <i className="bi bi-x-circle-fill text-danger mx-2"/>
-        <span className="text-secondary mx-1">{text}</span>
-    </div>
-);
-
-const Props = {
-    text: PropTypes.string,
-};
-
-const DefaultProps = {
-    text: "",
-};
-
-NotificationSuccess.propTypes = Props;
-NotificationSuccess.defaultProps = DefaultProps;
-
-NotificationError.propTypes = Props;
-NotificationError.defaultProps = DefaultProps;
-
-export {Notification, NotificationSuccess, NotificationError};
+export { Notification };

--- a/src/components/quiz/EndBox.jsx
+++ b/src/components/quiz/EndBox.jsx
@@ -3,6 +3,12 @@ import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 
 const EndBox = ({ endQuiz, totalTime, score = 0 }) => {
+  if (!score) {
+    if (sessionStorage.getItem("score") !== null) {
+      score = sessionStorage.getItem("score");
+    }
+  }
+  console.log(score);
   const calculatePercent = () => {
     let result = (score / totalTime) * 100;
     endQuiz(Math.round(result));

--- a/src/components/quiz/QuestionBox.jsx
+++ b/src/components/quiz/QuestionBox.jsx
@@ -32,6 +32,7 @@ const QuestionBox = ({ quizInfo, questions, endQuiz }) => {
   }
 
   if (number === questions.length || quizTime < 0) {
+    sessionStorage.setItem("score", quizTime);
     return (
       <EndBox
         endQuiz={endQuiz}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -11,10 +11,6 @@ import {
   createQuizAction,
   deleteQuizAction,
 } from "../utils/speedquiz";
-import {
-  NotificationSuccess,
-  NotificationError,
-} from "../components/Notifications";
 
 const Home = ({ address, name, balance, fetchBalance, disconnect }) => {
   const [loading, setLoading] = useState(false);
@@ -32,6 +28,7 @@ const Home = ({ address, name, balance, fetchBalance, disconnect }) => {
 
   const getQuizzes = useCallback(async () => {
     setLoading(true);
+    toast.info("Getting Your Info");
     getQuizzesAction(address)
       .then((quizzes) => {
         if (quizzes) {
@@ -65,32 +62,38 @@ const Home = ({ address, name, balance, fetchBalance, disconnect }) => {
   }, [address]);
 
   const createQuiz = async (data) => {
+    toast.info("Creating New Quiz");
     setLoading(true);
     createQuizAction(address, data)
       .then(() => {
-        toast(<NotificationSuccess text="Quiz added successfully." />);
+        toast.dismiss();
+        toast.success("Quiz added successfully.");
         getQuizzes();
         fetchBalance(address);
       })
       .catch((error) => {
         console.log(error);
         setLoading(false);
-        toast(<NotificationError text="Failed to create quiz." />);
+        toast.dismiss();
+        toast.error("Failed to create quiz.");
       });
   };
 
   const deleteQuiz = async (quiz) => {
+    toast.info("Deleting Quiz");
     setLoading(true);
     deleteQuizAction(address, quiz.appId)
       .then(() => {
-        toast(<NotificationSuccess text="Quiz deleted successfully" />);
+        toast.dismiss();
+        toast.success("Quiz deleted successfully");
         getQuizzes();
         fetchBalance(address);
       })
       .catch((error) => {
         console.log(error);
         setLoading(false);
-        toast(<NotificationError text="Failed to delete quiz." />);
+        toast.dismiss();
+        toast.success("Failed to delete quiz.");
       });
   };
 

--- a/src/pages/Quiz.jsx
+++ b/src/pages/Quiz.jsx
@@ -17,10 +17,6 @@ import {
   endQuizAction,
   optInAction,
 } from "../utils/speedquiz";
-import {
-  NotificationSuccess,
-  NotificationError,
-} from "../components/Notifications";
 import Loader from "../components/Loader";
 
 const Quiz = ({ address, name, balance, fetchBalance, disconnect }) => {
@@ -42,6 +38,7 @@ const Quiz = ({ address, name, balance, fetchBalance, disconnect }) => {
 
   const getQuizInfo = useCallback(async () => {
     setLoading(true);
+    toast.info("Getting Quiz Info");
     if (!quizId) return;
     const id = quizId.match(/(\d+)/);
     await getQuizApplication(Number(id[0]))
@@ -95,72 +92,90 @@ const Quiz = ({ address, name, balance, fetchBalance, disconnect }) => {
   );
 
   const optIn = async () => {
+    toast.info("Opting In...");
     setLoading(true);
     optInAction(address, quizInfo)
       .then(() => {
-        toast(<NotificationSuccess text="Player OptedIn." />);
+        toast.dismiss();
+        toast.success("Player OptedIn.");
         getPlayerInfo(true);
         fetchBalance(address);
       })
       .catch((error) => {
         console.log(error);
-        toast(<NotificationError text="Failed to opt in." />);
+        toast.dismiss();
+        toast.error("Failed to opt in.");
         setLoading(false);
       });
   };
 
   const createQuestion = async (data) => {
     setLoading(true);
+    toast.info("Adding Question");
     createQuestionAction(address, data, quizInfo)
       .then(() => {
-        toast(<NotificationSuccess text="Quiz added successfully." />);
+        toast.dismiss();
+        toast.success("Quiz added successfully.");
         getQuizInfo();
         getQuestions();
         fetchBalance(address);
       })
       .catch((error) => {
         console.log(error);
-        toast(<NotificationError text="Failed to create quiz." />);
+        toast.dismiss();
+        toast.error("Failed to create quiz.");
         setLoading(false);
       });
   };
 
   const startQuiz = async () => {
     setLoading(true);
-    startQuizAction(address, quizInfo)
+    toast.info("Starting Quiz Session");
+    startQuizAction(address, quizInfo, playerInfo)
       .then(async () => {
-        toast(<NotificationSuccess text="Quiz started successfully." />);
+        toast.dismiss();
+        toast.success("Quiz started successfully.");
         await getPlayerInfo(true);
         fetchBalance(address);
         setQuizStarted(true);
       })
       .catch((error) => {
         console.log(error);
-        toast(<NotificationError text="Failed to start quiz." />);
+        toast.dismiss();
+        toast.error("Failed to start quiz.");
         setLoading(false);
       });
   };
 
   const endQuiz = async (score) => {
     setLoading(true);
+    toast.info("Ending Quiz Session");
     endQuizAction(address, score, quizInfo)
       .then(() => {
-        toast(<NotificationSuccess text="Quiz ended successfully." />);
+        toast.dismiss();
+        toast.success("Quiz ended successfully.");
         fetchBalance(address);
         toResultsPage(score);
         setLoading(false);
+        sessionStorage.removeItem("score");
       })
       .catch((error) => {
         console.log(error);
-        toast(<NotificationError text="Failed to end quiz." />);
+        setQuizStarted(false);
+        toast.dismiss();
+        toast.error("Failed to end quiz.");
         setLoading(false);
       });
   };
 
   useEffect(() => {
-    getQuizInfo();
-    getQuestions();
-    getPlayerInfo();
+    let check = true;
+    if (check) {
+      getQuizInfo();
+      getQuestions();
+      getPlayerInfo();
+    }
+    return () => (check = false);
   }, [getQuizInfo, getQuestions, getPlayerInfo]);
 
   if (loading) return <Loader />;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -28,6 +28,7 @@ export const minRound = 21540981;
 
 // https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0002.md
 export const speedQuizNote = "speed-quiz-dapp:uv1";
+export const attemptNote = "quiz-attempt:uv0";
 
 // Maximum local storage allocation, immutable
 export const numLocalIntsQuiz = 3;


### PR DESCRIPTION
# Changes Made
1. Stored the player's final score in session storage to allow it to persist, as currently when the quiz session ends and the user reloads or loses network connectivity score is set to zero. Storage is cleared after the user ends the quiz.

2. Noticed a bug during gameplay, that immediately after completing a quiz session and the user is directed to the end quiz section if the user cancels the end quiz transaction, the user then gets access to the quiz's questions again, meaning they can retake the quiz as many times just by cancelling the end quiz transaction after they just completed that quiz.
Fixed this issue by setting the `quizStarted`  value to false if and when the quiz ended transaction fails.

3. I also noticed that the player history was not showing only the quizzes that the player had attempted but was showing all quizzes that were available, I fixed this issue, by attaching a note to the start quiz transaction, the note would then be added only to quizzes the player had not taken before, so we can then use that note to get quizzes that the player had attempted.

4. I updated the notifications of the code base to show more information while the pages were loading.

5. I fixed useEffect warning that popped up whenever the pages get redirected to the results page.

Here is the live demo [link](https://harmonious-cendol-d8bd74.netlify.app/)
